### PR TITLE
Add workflow for automatic PubMed updates

### DIFF
--- a/.github/workflows/update_pubmed.yml
+++ b/.github/workflows/update_pubmed.yml
@@ -1,0 +1,31 @@
+name: Update PubMed Publications
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # Every Sunday
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run update script
+        run: python update_pubmed.py
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add README.md
+          git commit -m "Auto-update PubMed publications" || echo "No changes"
+          git push


### PR DESCRIPTION
## Summary
- add GitHub action to update PubMed publications weekly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eca5aa598832d9202f5a186bd2093