### PR TITLE
Add scholar stats automation

### DIFF
--- a/.github/workflows/update_pubmed.yml
+++ b/.github/workflows/update_pubmed.yml
@@ -19,13 +19,16 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run update script
+      - name: Run PubMed update script
         run: python update_readme_pubmed.py
+
+      - name: Update Google Scholar stats
+        run: python update_scholar_stats.py
 
       - name: Commit and push changes
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git add README.md
-          git commit -m "Auto-update PubMed publications" || echo "No changes"
+          git commit -m "Auto-update PubMed publications and scholar stats" || echo "No changes"
           git push

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 <p align="center">
   <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/r/r-original.svg" alt="R icon" height="40"/>
   <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/rstudio/rstudio-original.svg" alt="RStudio icon" height="40"/>
+  <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/trinetx.svg" alt="TriNetX logo" height="40"/>
 </p>
 
 ## GitHub Stats
 
 ![Hunter's GitHub stats](https://github-readme-stats.vercel.app/api?username=huntereby&show_icons=true)
+**Google Scholar:** Citations: {{CITATION_COUNT}} | H-index: {{H_INDEX}}
 
 ## 📝 Recent Publications
 ![Update PubMed](https://github.com/huntereby/huntereby/actions/workflows/update_pubmed.yml/badge.svg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 biopython
 certifi
+scholarly

--- a/update_scholar_stats.py
+++ b/update_scholar_stats.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Update Google Scholar citation count in README.md."""
+"""Update Google Scholar citation count and h-index in README.md."""
 
 from __future__ import annotations
 
@@ -12,27 +12,34 @@ USER_ID = "rFZAeeEAAAAJ"
 README_PATH = Path(__file__).resolve().parent / "README.md"
 
 
-def fetch_citation_count(user_id: str) -> int:
-    """Return the total citation count for the given user."""
+def fetch_stats(user_id: str) -> tuple[int, int]:
+    """Return the citation count and h-index for the given user."""
     author = scholarly.search_author_id(user_id)
     author = scholarly.fill(author, sections=["indices"])
-    return author.get("citedby", 0)
+    citations = author.get("citedby", 0)
+    h_index = author.get("hindex", 0)
+    return citations, h_index
 
 
-def update_readme(citations: int) -> None:
-    """Replace citation placeholder in README with the provided value."""
+def update_readme(citations: int, h_index: int) -> None:
+    """Replace citation and h-index placeholders in README with the provided values."""
     text = README_PATH.read_text()
     text = re.sub(
-        r"Google_Scholar-(?:\d+|\{\{CITATION_COUNT\}\})_citations",
-        f"Google_Scholar-{citations}_citations",
+        r"Citations: (?:\d+|\{\{CITATION_COUNT\}\})",
+        f"Citations: {citations}",
+        text,
+    )
+    text = re.sub(
+        r"H-index: (?:\d+|\{\{H_INDEX\}\})",
+        f"H-index: {h_index}",
         text,
     )
     README_PATH.write_text(text)
 
 
 def main() -> None:
-    citations = fetch_citation_count(USER_ID)
-    update_readme(citations)
+    citations, h_index = fetch_stats(USER_ID)
+    update_readme(citations, h_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track Google Scholar citations and h-index in the README
- support citation/h-index update in `update_scholar_stats.py`
- install `scholarly` and run script weekly via workflow
- show TriNetX among the tool logos

## Testing
- `python update_scholar_stats.py` *(fails: No module named 'scholarly')*
- `python update_readme_pubmed.py` *(fails: No module named 'Bio')*


------
https://chatgpt.com/codex/tasks/task_e_685f1af4adf4832dba80587d7b865d32